### PR TITLE
v1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ dependencies {
 - `@FullText`에 선언된 `길이(length)`와 `각 필드에 선언된 @Field.length의 총합`이 일치하지 않을 경우 예외를 발생시킵니다.
 - 클래스 레벨에 `@FullText`가 누락돼있다면 예외를 발생시킵니다.
 - 필드 레벨에 `@Field`가 누락돼있다면 예외를 발생시킵니다.
+- `@FullText`와 `@Field`의 속성들 (`PadPosition`, `PadCharacter`)이 모두 `NONE`이면 예외를 발생시킵니다.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@
 
 # ⚙ 사용 방법
 
+이 모듈은 순수하게 자바 1.8로 작성됐습니다. 
+
+따라서 요구하는 최소한의 자바 버전은 1.8입니다.
+
 ## 📜 Maven
 ```xml
 <!--pom.xml-->
 <dependency>
   <groupId>io.github.shirohoo</groupId>
   <artifactId>full-text-mapper</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
 </dependency>
 ```
 
@@ -55,7 +59,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.github.shirohoo:full-text-mapper:1.2'
+    implementation 'io.github.shirohoo:full-text-mapper:1.3'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,9 @@ plugins {
 
 group = 'io.github.shirohoo'
 archivesBaseName = 'full-text-mapper'
-version = '1.2'
-sourceCompatibility = JavaVersion.VERSION_1_8
+version = '1.3'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {

--- a/src/main/java/fulltext/LineFullTextMapper.java
+++ b/src/main/java/fulltext/LineFullTextMapper.java
@@ -137,7 +137,7 @@ public final class LineFullTextMapper implements FullTextMapper {
         for (ClassCaster classCaster : ClassCaster.values()) {
             if (field.getType().equals(classCaster.getClazz())) {
                 String value = removePad(data, padCharacter, padPosition, getLength(field));
-                field.set(instance, classCaster.classCast().apply(value));
+                field.set(instance, classCaster.getFunction().apply(value));
                 data = data.substring(getLength(field));
             }
         }

--- a/src/main/java/fulltext/annotation/Field.java
+++ b/src/main/java/fulltext/annotation/Field.java
@@ -1,7 +1,6 @@
 package fulltext.annotation;
 
 import fulltext.FullTextMapper;
-import fulltext.enums.Charset;
 import fulltext.enums.PadCharacter;
 import fulltext.enums.PadPosition;
 import java.lang.annotation.Documented;
@@ -13,8 +12,7 @@ import java.lang.annotation.Target;
 /**
  * {@link FullTextMapper} refers to this annotation to mapping the fields of the object to the full text.
  * <p>
- * If the property declared in {@link Field} and the annotation declared in {@link FullText} are different,
- * the property declared in Field takes precedence.
+ * If the property declared in {@link Field} and the annotation declared in {@link FullText} are different, the property declared in Field takes precedence.
  */
 @Documented
 @Target(ElementType.FIELD)
@@ -23,19 +21,24 @@ public @interface Field {
 
     /**
      * length of this field
+     *
      * @return a length of one field in full text
      */
     int length() default 0;
 
     /**
      * padChar of this field. default is PadCharacter.SPACE
+     *
      * @return {@link PadCharacter}
+     * @throws UnsupportedOperationException If @FullText.PadCharacter and @Field.PadCharacter are both PadCharacter.NONE
      */
     PadCharacter padChar() default PadCharacter.NONE;
 
     /**
      * padPosition of this field. default is PadPosition.LEFT_PAD
+     *
      * @return {@link PadPosition}
+     * @throws UnsupportedOperationException If @FullText.PadPosition and @Field.PadPosition are both PadPosition.NONE
      */
     PadPosition padPosition() default PadPosition.NONE;
 

--- a/src/main/java/fulltext/annotation/Field.java
+++ b/src/main/java/fulltext/annotation/Field.java
@@ -31,12 +31,12 @@ public @interface Field {
      * padChar of this field. default is PadCharacter.SPACE
      * @return {@link PadCharacter}
      */
-    PadCharacter padChar() default PadCharacter.SPACE;
+    PadCharacter padChar() default PadCharacter.NONE;
 
     /**
      * padPosition of this field. default is PadPosition.LEFT_PAD
      * @return {@link PadPosition}
      */
-    PadPosition padPosition() default PadPosition.LEFT_PAD;
+    PadPosition padPosition() default PadPosition.NONE;
 
 }

--- a/src/main/java/fulltext/annotation/FullText.java
+++ b/src/main/java/fulltext/annotation/FullText.java
@@ -11,8 +11,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * {@link FullTextMapper} refers to this annotation to mapping the object to the full text.
- * set here are used globally only in class scope and do not take precedence over field level annotations.
+ * {@link FullTextMapper} refers to this annotation to mapping the object to the full text. set here are used globally only in class scope and do not take precedence over field level annotations.
  */
 @Documented
 @Target(ElementType.TYPE)
@@ -21,25 +20,31 @@ public @interface FullText {
 
     /**
      * Means the total length of one line in full text.
+     *
      * @return a total length of full text
      */
     int length();
 
     /**
      * Set how to encode full text. The default is UTF-8.
+     *
      * @return {@link Charset}
      */
     Charset encoding() default Charset.UTF_8;
 
     /**
      * Sets the padding character to be used in full text. The default is a space character(" ").
+     *
      * @return {@link PadCharacter}
+     * @throws UnsupportedOperationException If @FullText.PadCharacter and @Field.PadCharacter are both PadCharacter.NONE
      */
     PadCharacter padChar() default PadCharacter.SPACE;
 
     /**
      * Determines whether the pad is padded on the left or on the right. default is left.
+     *
      * @return {@link PadPosition}
+     * @throws UnsupportedOperationException If @FullText.PadPosition and @Field.PadPosition are both PadPosition.NONE
      */
     PadPosition padPosition() default PadPosition.LEFT;
 

--- a/src/main/java/fulltext/annotation/FullText.java
+++ b/src/main/java/fulltext/annotation/FullText.java
@@ -41,6 +41,6 @@ public @interface FullText {
      * Determines whether the pad is padded on the left or on the right. default is left.
      * @return {@link PadPosition}
      */
-    PadPosition padPosition() default PadPosition.LEFT_PAD;
+    PadPosition padPosition() default PadPosition.LEFT;
 
 }

--- a/src/main/java/fulltext/annotation/FullTextReflector.java
+++ b/src/main/java/fulltext/annotation/FullTextReflector.java
@@ -86,7 +86,14 @@ public final class FullTextReflector {
     public static PadCharacter getPadCharacter(final FullText classAnnotation, final Field fieldAnnotation) {
         final PadCharacter cpc = classAnnotation.padChar();
         final PadCharacter fpc = fieldAnnotation.padChar();
-        return cpc.equals(fpc) ? cpc : fpc;
+
+        if (fpc.isNone()) {
+            return cpc;
+        }
+        if (cpc.equals(fpc)) {
+            return cpc;
+        }
+        return fpc;
     }
 
     /**
@@ -99,7 +106,14 @@ public final class FullTextReflector {
     public static PadPosition getPadPosition(final FullText classAnnotation, final Field fieldAnnotation) {
         final PadPosition cpp = classAnnotation.padPosition();
         final PadPosition fpp = fieldAnnotation.padPosition();
-        return cpp.equals(fpp) ? cpp : fpp;
+
+        if (fpp.isNone()) {
+            return cpp;
+        }
+        if (cpp.equals(fpp)) {
+            return cpp;
+        }
+        return fpp;
     }
 
     /**

--- a/src/main/java/fulltext/annotation/FullTextReflector.java
+++ b/src/main/java/fulltext/annotation/FullTextReflector.java
@@ -83,14 +83,14 @@ public final class FullTextReflector {
      * @param fieldAnnotation a declared {@link Field} annotation at field level.
      * @return {@link PadCharacter}
      */
-    public static PadCharacter getPadCharacter(final FullText classAnnotation, final Field fieldAnnotation) {
+    public static PadCharacter getPadCharacter(final FullText classAnnotation, final Field fieldAnnotation) throws UnsupportedOperationException {
         final PadCharacter cpc = classAnnotation.padChar();
         final PadCharacter fpc = fieldAnnotation.padChar();
 
-        if (fpc.isNone()) {
-            return cpc;
+        if (cpc.isNone() && fpc.isNone()) {
+            throw new UnsupportedOperationException("Both @FullText and @Field can't be PadCharacter.NONE");
         }
-        if (cpc.equals(fpc)) {
+        if (fpc.isNone() || cpc == fpc) {
             return cpc;
         }
         return fpc;
@@ -103,14 +103,14 @@ public final class FullTextReflector {
      * @param fieldAnnotation a declared {@link Field} annotation at field level.
      * @return {@link PadPosition}
      */
-    public static PadPosition getPadPosition(final FullText classAnnotation, final Field fieldAnnotation) {
+    public static PadPosition getPadPosition(final FullText classAnnotation, final Field fieldAnnotation) throws UnsupportedOperationException {
         final PadPosition cpp = classAnnotation.padPosition();
         final PadPosition fpp = fieldAnnotation.padPosition();
 
-        if (fpp.isNone()) {
-            return cpp;
+        if (cpp.isNone() && fpp.isNone()) {
+            throw new UnsupportedOperationException("Both @FullText and @Field can't be PadCharacter.NONE");
         }
-        if (cpp.equals(fpp)) {
+        if (fpp.isNone() || cpp == fpp) {
             return cpp;
         }
         return fpp;

--- a/src/main/java/fulltext/annotation/FullTextReflector.java
+++ b/src/main/java/fulltext/annotation/FullTextReflector.java
@@ -108,7 +108,7 @@ public final class FullTextReflector {
         final PadPosition fpp = fieldAnnotation.padPosition();
 
         if (cpp.isNone() && fpp.isNone()) {
-            throw new UnsupportedOperationException("Both @FullText and @Field can't be PadCharacter.NONE");
+            throw new UnsupportedOperationException("Both @FullText and @Field can't be PadPosition.NONE");
         }
         if (fpp.isNone() || cpp == fpp) {
             return cpp;

--- a/src/main/java/fulltext/enums/ClassCaster.java
+++ b/src/main/java/fulltext/enums/ClassCaster.java
@@ -21,19 +21,19 @@ public enum ClassCaster {
     ;
 
     private final Class<?> clazz;
-    private final Function<String, ?> castFunction;
+    private final Function<String, ?> function;
 
-    ClassCaster(final Class<?> clazz, final Function<String, ?> castFunction) {
+    ClassCaster(final Class<?> clazz, final Function<String, ?> function) {
         this.clazz = clazz;
-        this.castFunction = castFunction;
+        this.function = function;
     }
 
     public Class<?> getClazz() {
         return clazz;
     }
 
-    public Function<String, ?> classCast() {
-        return castFunction;
+    public Function<String, ?> getFunction() {
+        return function;
     }
 
 }

--- a/src/main/java/fulltext/enums/PadCharacter.java
+++ b/src/main/java/fulltext/enums/PadCharacter.java
@@ -2,6 +2,7 @@ package fulltext.enums;
 
 public enum PadCharacter {
 
+    NONE(""),
     SPACE(" "),
     ZERO("0"),
     ;

--- a/src/main/java/fulltext/enums/PadCharacter.java
+++ b/src/main/java/fulltext/enums/PadCharacter.java
@@ -13,6 +13,10 @@ public enum PadCharacter {
         this.character = character;
     }
 
+    public boolean isNone() {
+        return this == NONE;
+    }
+
     public String leftPad(final String data, final int len) {
         return pad(len) + data;
     }

--- a/src/main/java/fulltext/enums/PadPosition.java
+++ b/src/main/java/fulltext/enums/PadPosition.java
@@ -3,8 +3,8 @@ package fulltext.enums;
 public enum PadPosition {
 
     NONE,
-    LEFT_PAD,
-    RIGHT_PAD,
+    LEFT,
+    RIGHT,
     ;
 
     public boolean isNone() {
@@ -12,7 +12,7 @@ public enum PadPosition {
     }
 
     public boolean isLeft() {
-        return this == LEFT_PAD;
+        return this == LEFT;
     }
 
 }

--- a/src/main/java/fulltext/enums/PadPosition.java
+++ b/src/main/java/fulltext/enums/PadPosition.java
@@ -7,6 +7,10 @@ public enum PadPosition {
     RIGHT_PAD,
     ;
 
+    public boolean isNone() {
+        return this == NONE;
+    }
+
     public boolean isLeft() {
         return this == LEFT_PAD;
     }

--- a/src/main/java/fulltext/enums/PadPosition.java
+++ b/src/main/java/fulltext/enums/PadPosition.java
@@ -2,6 +2,7 @@ package fulltext.enums;
 
 public enum PadPosition {
 
+    NONE,
     LEFT_PAD,
     RIGHT_PAD,
     ;

--- a/src/test/java/fulltext/ClassCasterTest.java
+++ b/src/test/java/fulltext/ClassCasterTest.java
@@ -26,8 +26,7 @@ class ClassCasterTest {
     @MethodSource
     @ParameterizedTest
     void castFunction(final String data, final Function<String, ?> castFunction, final Object expected) throws Exception {
-        Object actual = castFunction.apply(data);
-        assertThat(actual).isEqualTo(expected);
+        assertThat(castFunction.apply(data)).isEqualTo(expected);
     }
 
     private static Stream<Arguments> castFunction() {

--- a/src/test/java/fulltext/ClassCasterTest.java
+++ b/src/test/java/fulltext/ClassCasterTest.java
@@ -25,22 +25,22 @@ class ClassCasterTest {
 
     @MethodSource
     @ParameterizedTest
-    void castFunction(final String data, final Function<String, ?> castFunction, final Object expected) throws Exception {
-        assertThat(castFunction.apply(data)).isEqualTo(expected);
+    void function(final String data, final Function<String, ?> function, final Object expected) throws Exception {
+        assertThat(function.apply(data)).isEqualTo(expected);
     }
 
-    private static Stream<Arguments> castFunction() {
+    private static Stream<Arguments> function() {
         return Stream.of(
-            Arguments.of("1000", STRING.classCast(), "1000"),
-            Arguments.of("1000", INT.classCast(), 1000),
-            Arguments.of("1000", INT_WRAPPER.classCast(), 1000),
-            Arguments.of("1000", LONG.classCast(), 1000L),
-            Arguments.of("1000", LONG_WRAPPER.classCast(), 1000L),
-            Arguments.of("1000.0", DOUBLE.classCast(), 1000.0D),
-            Arguments.of("1000.0", DOUBLE_WRAPPER.classCast(), 1000.0D),
-            Arguments.of("20201010", LOCAL_DATE.classCast(), LocalDate.of(2020, 10, 10)),
-            Arguments.of("20201010000000", LOCAL_DATE_TIME.classCast(), LocalDateTime.parse("20201010000000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))),
-            Arguments.of("1000", BIG_DECIMAL.classCast(), new BigDecimal("1000"))
+            Arguments.of("1000", STRING.getFunction(), "1000"),
+            Arguments.of("1000", INT.getFunction(), 1000),
+            Arguments.of("1000", INT_WRAPPER.getFunction(), 1000),
+            Arguments.of("1000", LONG.getFunction(), 1000L),
+            Arguments.of("1000", LONG_WRAPPER.getFunction(), 1000L),
+            Arguments.of("1000.0", DOUBLE.getFunction(), 1000.0D),
+            Arguments.of("1000.0", DOUBLE_WRAPPER.getFunction(), 1000.0D),
+            Arguments.of("20201010", LOCAL_DATE.getFunction(), LocalDate.of(2020, 10, 10)),
+            Arguments.of("20201010000000", LOCAL_DATE_TIME.getFunction(), LocalDateTime.parse("20201010000000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))),
+            Arguments.of("1000", BIG_DECIMAL.getFunction(), new BigDecimal("1000"))
         );
     }
 

--- a/src/test/java/fulltext/LineFullTextMapperTest.java
+++ b/src/test/java/fulltext/LineFullTextMapperTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fulltext.fixture.FullTextCreator;
 import fulltext.fixture.ModelCreator;
-import fulltext.model.InvalidClassAnnotationModel;
-import fulltext.model.ValidModel;
-import fulltext.model.ValidOptionModel;
+import fulltext.fixture.model.InvalidClassAnnotationModel;
+import fulltext.fixture.model.ValidModel;
+import fulltext.fixture.model.ValidOptionModel;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/fulltext/LineFullTextMapperTest.java
+++ b/src/test/java/fulltext/LineFullTextMapperTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fulltext.fixture.FullTextCreator;
 import fulltext.fixture.ModelCreator;
 import fulltext.fixture.model.InvalidClassAnnotationModel;
+import fulltext.fixture.model.UnsupportedAnnotationModel;
 import fulltext.fixture.model.ValidModel;
 import fulltext.fixture.model.ValidOptionModel;
 import java.util.Optional;
@@ -38,6 +39,13 @@ class LineFullTextMapperTest {
         assertThatThrownBy(() -> mapper.readValue(FullTextCreator.VALID_DATA, InvalidClassAnnotationModel.class))
             .hasMessage("There is a problem with setting the full text object. @FullText: 301, @Field total length: 300")
             .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void readValue_exception_3() throws Exception {
+        assertThatThrownBy(() -> mapper.readValue(FullTextCreator.VALID_DATA, UnsupportedAnnotationModel.class))
+            .hasMessageMatching("Both @FullText and @Field can't be [a-zA-Z]*.NONE")
+            .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/src/test/java/fulltext/LineFullTextMapperTest.java
+++ b/src/test/java/fulltext/LineFullTextMapperTest.java
@@ -16,40 +16,40 @@ class LineFullTextMapperTest {
 
     @Test
     void readValue() throws Exception {
-        Optional<ValidModel> actual = mapper.readValue(FullTextCreator.validData(), ValidModel.class);
-        assertThat(actual.get()).isEqualTo(ModelCreator.validModel());
+        Optional<ValidModel> actual = mapper.readValue(FullTextCreator.VALID_DATA, ValidModel.class);
+        assertThat(actual.get()).isEqualTo(ModelCreator.VALID_MODEL);
     }
 
     @Test
     void readValue_option() throws Exception {
-        Optional<ValidOptionModel> actual = mapper.readValue(FullTextCreator.validOptionData(), ValidOptionModel.class);
-        assertThat(actual.get()).isEqualTo(ModelCreator.validOptionModel());
+        Optional<ValidOptionModel> actual = mapper.readValue(FullTextCreator.VALID_OPTION_DATA, ValidOptionModel.class);
+        assertThat(actual.get()).isEqualTo(ModelCreator.VALID_OPTION_MODEL);
     }
 
     @Test
     void readValue_exception_1() throws Exception {
-        assertThatThrownBy(() -> mapper.readValue(FullTextCreator.validData(), null))
+        assertThatThrownBy(() -> mapper.readValue(FullTextCreator.VALID_DATA, null))
             .hasMessage("Class is must not be null.")
             .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void readValue_exception_2() throws Exception {
-        assertThatThrownBy(() -> mapper.readValue(FullTextCreator.validData(), InvalidClassAnnotationModel.class))
+        assertThatThrownBy(() -> mapper.readValue(FullTextCreator.VALID_DATA, InvalidClassAnnotationModel.class))
             .hasMessage("There is a problem with setting the full text object. @FullText: 301, @Field total length: 300")
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void write() throws Exception {
-        String actual = mapper.write(ModelCreator.validModel());
-        assertThat(actual).isEqualTo(FullTextCreator.validModel());
+        String actual = mapper.write(ModelCreator.VALID_MODEL);
+        assertThat(actual).isEqualTo(FullTextCreator.VALID_DATA);
     }
 
     @Test
     void write_option() throws Exception {
-        String actual = mapper.write(ModelCreator.validOptionModel());
-        assertThat(actual).isEqualTo(FullTextCreator.validOptionData());
+        String actual = mapper.write(ModelCreator.VALID_OPTION_MODEL);
+        assertThat(actual).isEqualTo(FullTextCreator.VALID_OPTION_DATA);
     }
 
 }

--- a/src/test/java/fulltext/PadCharacterTest.java
+++ b/src/test/java/fulltext/PadCharacterTest.java
@@ -11,6 +11,20 @@ class PadCharacterTest {
 
     @MethodSource
     @ParameterizedTest
+    void isNone(final PadCharacter padCharacter, final boolean expected) throws Exception {
+        assertThat(padCharacter.isNone()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> isNone() {
+        return Stream.of(
+            Arguments.of(PadCharacter.NONE, true),
+            Arguments.of(PadCharacter.SPACE, false),
+            Arguments.of(PadCharacter.ZERO, false)
+        );
+    }
+
+    @MethodSource
+    @ParameterizedTest
     void pad(final PadCharacter padCharacter, final int padLen, final String expected) throws Exception {
         String actual = padCharacter.pad(padLen);
         assertThat(actual).isEqualTo(expected);

--- a/src/test/java/fulltext/annotation/FullTextReflectorTest.java
+++ b/src/test/java/fulltext/annotation/FullTextReflectorTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fulltext.enums.Charset;
 import fulltext.enums.PadCharacter;
 import fulltext.enums.PadPosition;
-import fulltext.model.InvalidClassAnnotationModel;
-import fulltext.model.NoClassAnnotationModel;
-import fulltext.model.ValidModel;
-import fulltext.model.ValidOptionModel;
+import fulltext.fixture.model.InvalidClassAnnotationModel;
+import fulltext.fixture.model.NoClassAnnotationModel;
+import fulltext.fixture.model.ValidModel;
+import fulltext.fixture.model.ValidOptionModel;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
@@ -111,22 +111,22 @@ class FullTextReflectorTest {
     }
 
     private static java.lang.reflect.Field validField() throws Exception {
-        final Class<?> clazz = Class.forName("fulltext.model.ValidModel");
+        final Class<?> clazz = Class.forName("fulltext.fixture.model.ValidModel");
         return clazz.getDeclaredField("headerType");
     }
 
     private static java.lang.reflect.Field validOptionAgeField() throws Exception {
-        final Class<?> clazz = Class.forName("fulltext.model.ValidOptionModel");
+        final Class<?> clazz = Class.forName("fulltext.fixture.model.ValidOptionModel");
         return clazz.getDeclaredField("age");
     }
 
     private static java.lang.reflect.Field validOptionNameField() throws Exception {
-        final Class<?> clazz = Class.forName("fulltext.model.ValidOptionModel");
+        final Class<?> clazz = Class.forName("fulltext.fixture.model.ValidOptionModel");
         return clazz.getDeclaredField("name");
     }
 
     private static java.lang.reflect.Field invalidField() throws Exception {
-        final Class<?> clazz = Class.forName("fulltext.model.NoFieldAnnotationModel");
+        final Class<?> clazz = Class.forName("fulltext.fixture.model.NoFieldAnnotationModel");
         return clazz.getDeclaredField("headerType");
     }
 

--- a/src/test/java/fulltext/annotation/FullTextReflectorTest.java
+++ b/src/test/java/fulltext/annotation/FullTextReflectorTest.java
@@ -93,7 +93,7 @@ class FullTextReflectorTest {
         final PadPosition padPosition = FullTextReflector.getPadPosition(classAnnotation, fieldAnnotation);
 
         // then
-        assertThat(padPosition).isEqualTo(PadPosition.RIGHT_PAD);
+        assertThat(padPosition).isEqualTo(PadPosition.RIGHT);
     }
 
     @Test

--- a/src/test/java/fulltext/enums/PadPositionTest.java
+++ b/src/test/java/fulltext/enums/PadPositionTest.java
@@ -1,0 +1,39 @@
+package fulltext.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PadPositionTest {
+
+    @MethodSource
+    @ParameterizedTest
+    void isNone(final PadPosition PadPosition, final boolean expected) throws Exception {
+        assertThat(PadPosition.isNone()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> isNone() {
+        return Stream.of(
+            Arguments.of(PadPosition.NONE, true),
+            Arguments.of(PadPosition.LEFT_PAD, false),
+            Arguments.of(PadPosition.RIGHT_PAD, false)
+        );
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void isLeft(final PadPosition PadPosition, final boolean expected) throws Exception {
+        assertThat(PadPosition.isLeft()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> isLeft() {
+        return Stream.of(
+            Arguments.of(PadPosition.NONE, false),
+            Arguments.of(PadPosition.LEFT_PAD, true),
+            Arguments.of(PadPosition.RIGHT_PAD, false)
+        );
+    }
+
+}

--- a/src/test/java/fulltext/enums/PadPositionTest.java
+++ b/src/test/java/fulltext/enums/PadPositionTest.java
@@ -17,8 +17,8 @@ class PadPositionTest {
     private static Stream<Arguments> isNone() {
         return Stream.of(
             Arguments.of(PadPosition.NONE, true),
-            Arguments.of(PadPosition.LEFT_PAD, false),
-            Arguments.of(PadPosition.RIGHT_PAD, false)
+            Arguments.of(PadPosition.LEFT, false),
+            Arguments.of(PadPosition.RIGHT, false)
         );
     }
 
@@ -31,8 +31,8 @@ class PadPositionTest {
     private static Stream<Arguments> isLeft() {
         return Stream.of(
             Arguments.of(PadPosition.NONE, false),
-            Arguments.of(PadPosition.LEFT_PAD, true),
-            Arguments.of(PadPosition.RIGHT_PAD, false)
+            Arguments.of(PadPosition.LEFT, true),
+            Arguments.of(PadPosition.RIGHT, false)
         );
     }
 

--- a/src/test/java/fulltext/fixture/FullTextCreator.java
+++ b/src/test/java/fulltext/fixture/FullTextCreator.java
@@ -2,23 +2,12 @@ package fulltext.fixture;
 
 public final class FullTextCreator {
 
-    public static String validData() {
-        return "120211011                                                                                           " +
-            "2      siro 28                                                                                      " +
-            "3                                                                                                   ";
-    }
-
-    public static String validOptionData() {
-        return "120211011                                                                                          " +
-            " 2siro      028                                                                                     " +
-            " 3                                                                                                   ";
-    }
-
-    public static String validModel() {
-        return "120211011                                                                                           "
-            + "2      siro 28                                                                                "
-            + "      3                                                                                       "
-            + "            ";
-    }
+    public static final String VALID_DATA = "120211011                                                                                           " +
+        "2      siro 28                                                                                      " +
+        "3                                                                                                   ";
+    
+    public static final String VALID_OPTION_DATA = "120211011                                                                                          " +
+        " 2siro      028                                                                                     " +
+        " 3                                                                                                   ";
 
 }

--- a/src/test/java/fulltext/fixture/ModelCreator.java
+++ b/src/test/java/fulltext/fixture/ModelCreator.java
@@ -9,8 +9,8 @@ import java.time.format.DateTimeFormatter;
 
 public final class ModelCreator {
 
-    public static ValidModel validModel() {
-        return ValidModel.builder()
+    public static final ValidModel VALID_MODEL =
+        ValidModel.builder()
             .headerType("1")
             .createAt(LocalDate.parse("20211011", DateTimeFormatter.BASIC_ISO_DATE))
             .headerPadding("")
@@ -21,10 +21,9 @@ public final class ModelCreator {
             .trailerType("3")
             .trailerPadding("")
             .build();
-    }
 
-    public static ValidOptionModel validOptionModel() {
-        return ValidOptionModel.builder()
+    public static final ValidOptionModel VALID_OPTION_MODEL =
+        ValidOptionModel.builder()
             .headerType("1")
             .createAt(LocalDate.parse("20211011", DateTimeFormatter.BASIC_ISO_DATE))
             .headerPadding("")
@@ -35,10 +34,9 @@ public final class ModelCreator {
             .trailerType("3")
             .trailerPadding("")
             .build();
-    }
 
-    public static InvalidClassAnnotationModel invalidClassAnnotationModel() {
-        return InvalidClassAnnotationModel.builder()
+    public static final InvalidClassAnnotationModel INVALID_CLASS_ANNOTATION_MODEL =
+        InvalidClassAnnotationModel.builder()
             .headerType("1")
             .createAt(LocalDate.parse("20211011", DateTimeFormatter.BASIC_ISO_DATE))
             .headerPadding("")
@@ -49,10 +47,9 @@ public final class ModelCreator {
             .trailerType("3")
             .trailerPadding("")
             .build();
-    }
 
-    public static NoClassAnnotationModel noClassAnnotationModel() {
-        return NoClassAnnotationModel.builder()
+    public static final NoClassAnnotationModel NO_CLASS_ANNOTATION_MODEL =
+        NoClassAnnotationModel.builder()
             .headerType("1")
             .createAt(LocalDate.parse("20211011", DateTimeFormatter.BASIC_ISO_DATE))
             .headerPadding("")
@@ -63,6 +60,5 @@ public final class ModelCreator {
             .trailerType("3")
             .trailerPadding("")
             .build();
-    }
 
 }

--- a/src/test/java/fulltext/fixture/ModelCreator.java
+++ b/src/test/java/fulltext/fixture/ModelCreator.java
@@ -1,9 +1,9 @@
 package fulltext.fixture;
 
-import fulltext.model.InvalidClassAnnotationModel;
-import fulltext.model.NoClassAnnotationModel;
-import fulltext.model.ValidModel;
-import fulltext.model.ValidOptionModel;
+import fulltext.fixture.model.InvalidClassAnnotationModel;
+import fulltext.fixture.model.NoClassAnnotationModel;
+import fulltext.fixture.model.ValidModel;
+import fulltext.fixture.model.ValidOptionModel;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 

--- a/src/test/java/fulltext/fixture/model/InvalidClassAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/InvalidClassAnnotationModel.java
@@ -1,41 +1,50 @@
-package fulltext.model;
+package fulltext.fixture.model;
 
 import fulltext.annotation.Field;
-import fulltext.annotation.FullText;
 import fulltext.enums.Charset;
+import fulltext.annotation.FullText;
 import fulltext.enums.PadCharacter;
 import java.time.LocalDate;
 import java.util.Objects;
 
 @FullText(
-    length = 300,
+    length = 301,
     encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
     padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
 )
-public class NoFieldAnnotationModel {
+public class InvalidClassAnnotationModel {
 
+    @Field(length = 1)
     private String headerType;
 
+    @Field(length = 8)
     private LocalDate createAt; // yyyyMMdd
 
+    @Field(length = 91)
     private String headerPadding;
 
+    @Field(length = 1)
     private String dataType;
 
+    @Field(length = 10)
     private String name;
 
+    @Field(length = 3)
     private int age;
 
+    @Field(length = 86)
     private String dataPadding;
 
+    @Field(length = 1)
     private String trailerType;
 
+    @Field(length = 99)
     private String trailerPadding;
 
-    private NoFieldAnnotationModel() {
+    private InvalidClassAnnotationModel() {
     }
 
-    private NoFieldAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+    private InvalidClassAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
         final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
         this.headerType = headerType;
         this.createAt = createAt;
@@ -48,8 +57,8 @@ public class NoFieldAnnotationModel {
         this.trailerPadding = trailerPadding;
     }
 
-    public static ValidModelBuilder builder() {
-        return new ValidModelBuilder();
+    public static InvalidClassAnnotationModelBuilder builder() {
+        return new InvalidClassAnnotationModelBuilder();
     }
 
     @Override
@@ -75,7 +84,7 @@ public class NoFieldAnnotationModel {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final NoFieldAnnotationModel validModel = (NoFieldAnnotationModel) o;
+        final InvalidClassAnnotationModel validModel = (InvalidClassAnnotationModel) o;
         return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
             dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
             trailerPadding, validModel.trailerPadding);
@@ -86,7 +95,7 @@ public class NoFieldAnnotationModel {
         return Objects.hash(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
     }
 
-    public static class ValidModelBuilder {
+    public static class InvalidClassAnnotationModelBuilder {
 
         private String headerType;
         private LocalDate createAt;
@@ -98,53 +107,53 @@ public class NoFieldAnnotationModel {
         private String trailerType;
         private String trailerPadding;
 
-        public ValidModelBuilder headerType(final String headerType) {
+        public InvalidClassAnnotationModelBuilder headerType(final String headerType) {
             this.headerType = headerType;
             return this;
         }
 
-        public ValidModelBuilder createAt(final LocalDate createAt) {
+        public InvalidClassAnnotationModelBuilder createAt(final LocalDate createAt) {
             this.createAt = createAt;
             return this;
         }
 
-        public ValidModelBuilder headerPadding(final String headerPadding) {
+        public InvalidClassAnnotationModelBuilder headerPadding(final String headerPadding) {
             this.headerPadding = headerPadding;
             return this;
         }
 
-        public ValidModelBuilder dataType(final String dataType) {
+        public InvalidClassAnnotationModelBuilder dataType(final String dataType) {
             this.dataType = dataType;
             return this;
         }
 
-        public ValidModelBuilder name(final String name) {
+        public InvalidClassAnnotationModelBuilder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public ValidModelBuilder age(final int age) {
+        public InvalidClassAnnotationModelBuilder age(final int age) {
             this.age = age;
             return this;
         }
 
-        public ValidModelBuilder dataPadding(final String dataPadding) {
+        public InvalidClassAnnotationModelBuilder dataPadding(final String dataPadding) {
             this.dataPadding = dataPadding;
             return this;
         }
 
-        public ValidModelBuilder trailerType(final String trailerType) {
+        public InvalidClassAnnotationModelBuilder trailerType(final String trailerType) {
             this.trailerType = trailerType;
             return this;
         }
 
-        public ValidModelBuilder trailerPadding(final String trailerPadding) {
+        public InvalidClassAnnotationModelBuilder trailerPadding(final String trailerPadding) {
             this.trailerPadding = trailerPadding;
             return this;
         }
 
-        public NoFieldAnnotationModel build() {
-            return new NoFieldAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        public InvalidClassAnnotationModel build() {
+            return new InvalidClassAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
 
     }

--- a/src/test/java/fulltext/fixture/model/NoClassAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/NoClassAnnotationModel.java
@@ -1,18 +1,10 @@
-package fulltext.model;
+package fulltext.fixture.model;
 
 import fulltext.annotation.Field;
-import fulltext.enums.Charset;
-import fulltext.annotation.FullText;
-import fulltext.enums.PadCharacter;
 import java.time.LocalDate;
 import java.util.Objects;
 
-@FullText(
-    length = 301,
-    encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
-    padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
-)
-public class InvalidClassAnnotationModel {
+public class NoClassAnnotationModel {
 
     @Field(length = 1)
     private String headerType;
@@ -41,10 +33,10 @@ public class InvalidClassAnnotationModel {
     @Field(length = 99)
     private String trailerPadding;
 
-    private InvalidClassAnnotationModel() {
+    private NoClassAnnotationModel() {
     }
 
-    private InvalidClassAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+    private NoClassAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
         final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
         this.headerType = headerType;
         this.createAt = createAt;
@@ -57,8 +49,8 @@ public class InvalidClassAnnotationModel {
         this.trailerPadding = trailerPadding;
     }
 
-    public static InvalidClassAnnotationModelBuilder builder() {
-        return new InvalidClassAnnotationModelBuilder();
+    public static NoClassAnnotationModelBuilder builder() {
+        return new NoClassAnnotationModelBuilder();
     }
 
     @Override
@@ -84,7 +76,7 @@ public class InvalidClassAnnotationModel {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final InvalidClassAnnotationModel validModel = (InvalidClassAnnotationModel) o;
+        final NoClassAnnotationModel validModel = (NoClassAnnotationModel) o;
         return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
             dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
             trailerPadding, validModel.trailerPadding);
@@ -95,7 +87,7 @@ public class InvalidClassAnnotationModel {
         return Objects.hash(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
     }
 
-    public static class InvalidClassAnnotationModelBuilder {
+    public static class NoClassAnnotationModelBuilder {
 
         private String headerType;
         private LocalDate createAt;
@@ -107,53 +99,53 @@ public class InvalidClassAnnotationModel {
         private String trailerType;
         private String trailerPadding;
 
-        public InvalidClassAnnotationModelBuilder headerType(final String headerType) {
+        public NoClassAnnotationModelBuilder headerType(final String headerType) {
             this.headerType = headerType;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder createAt(final LocalDate createAt) {
+        public NoClassAnnotationModelBuilder createAt(final LocalDate createAt) {
             this.createAt = createAt;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder headerPadding(final String headerPadding) {
+        public NoClassAnnotationModelBuilder headerPadding(final String headerPadding) {
             this.headerPadding = headerPadding;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder dataType(final String dataType) {
+        public NoClassAnnotationModelBuilder dataType(final String dataType) {
             this.dataType = dataType;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder name(final String name) {
+        public NoClassAnnotationModelBuilder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder age(final int age) {
+        public NoClassAnnotationModelBuilder age(final int age) {
             this.age = age;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder dataPadding(final String dataPadding) {
+        public NoClassAnnotationModelBuilder dataPadding(final String dataPadding) {
             this.dataPadding = dataPadding;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder trailerType(final String trailerType) {
+        public NoClassAnnotationModelBuilder trailerType(final String trailerType) {
             this.trailerType = trailerType;
             return this;
         }
 
-        public InvalidClassAnnotationModelBuilder trailerPadding(final String trailerPadding) {
+        public NoClassAnnotationModelBuilder trailerPadding(final String trailerPadding) {
             this.trailerPadding = trailerPadding;
             return this;
         }
 
-        public InvalidClassAnnotationModel build() {
-            return new InvalidClassAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        public NoClassAnnotationModel build() {
+            return new NoClassAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
 
     }

--- a/src/test/java/fulltext/fixture/model/NoFieldAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/NoFieldAnnotationModel.java
@@ -1,8 +1,7 @@
-package fulltext.model;
+package fulltext.fixture.model;
 
-import fulltext.annotation.Field;
-import fulltext.enums.Charset;
 import fulltext.annotation.FullText;
+import fulltext.enums.Charset;
 import fulltext.enums.PadCharacter;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -12,39 +11,30 @@ import java.util.Objects;
     encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
     padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
 )
-public class ValidModel {
+public class NoFieldAnnotationModel {
 
-    @Field(length = 1)
     private String headerType;
 
-    @Field(length = 8)
     private LocalDate createAt; // yyyyMMdd
 
-    @Field(length = 91)
     private String headerPadding;
 
-    @Field(length = 1)
     private String dataType;
 
-    @Field(length = 10)
     private String name;
 
-    @Field(length = 3)
     private int age;
 
-    @Field(length = 86)
     private String dataPadding;
 
-    @Field(length = 1)
     private String trailerType;
 
-    @Field(length = 99)
     private String trailerPadding;
 
-    private ValidModel() {
+    private NoFieldAnnotationModel() {
     }
 
-    private ValidModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+    private NoFieldAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
         final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
         this.headerType = headerType;
         this.createAt = createAt;
@@ -84,7 +74,7 @@ public class ValidModel {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final ValidModel validModel = (ValidModel) o;
+        final NoFieldAnnotationModel validModel = (NoFieldAnnotationModel) o;
         return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
             dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
             trailerPadding, validModel.trailerPadding);
@@ -152,8 +142,8 @@ public class ValidModel {
             return this;
         }
 
-        public ValidModel build() {
-            return new ValidModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        public NoFieldAnnotationModel build() {
+            return new NoFieldAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
 
     }

--- a/src/test/java/fulltext/fixture/model/UnsupportedAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/UnsupportedAnnotationModel.java
@@ -1,0 +1,161 @@
+package fulltext.fixture.model;
+
+import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import fulltext.enums.Charset;
+import fulltext.enums.PadCharacter;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@FullText(
+    length = 300,
+    encoding = Charset.UTF_8,
+    padChar = PadCharacter.NONE // @Field도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+)
+public class UnsupportedAnnotationModel {
+
+    @Field(length = 1, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String headerType;
+
+    @Field(length = 8, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private LocalDate createAt; // yyyyMMdd
+
+    @Field(length = 91, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String headerPadding;
+
+    @Field(length = 1, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String dataType;
+
+    @Field(length = 10, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String name;
+
+    @Field(length = 3, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private int age;
+
+    @Field(length = 86, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String dataPadding;
+
+    @Field(length = 1, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String trailerType;
+
+    @Field(length = 99, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
+    private String trailerPadding;
+
+    private UnsupportedAnnotationModel() {
+    }
+
+    private UnsupportedAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+        final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
+        this.headerType = headerType;
+        this.createAt = createAt;
+        this.headerPadding = headerPadding;
+        this.dataType = dataType;
+        this.name = name;
+        this.age = age;
+        this.dataPadding = dataPadding;
+        this.trailerType = trailerType;
+        this.trailerPadding = trailerPadding;
+    }
+
+    public static UnsupportedAnnotationModelBuilder builder() {
+        return new UnsupportedAnnotationModelBuilder();
+    }
+
+    @Override
+    public String toString() {
+        return "fulltext.TestModel{" +
+            "headerType='" + headerType + '\'' +
+            ", createAt='" + createAt + '\'' +
+            ", headerPadding='" + headerPadding + '\'' +
+            ", dataType='" + dataType + '\'' +
+            ", name='" + name + '\'' +
+            ", age='" + age + '\'' +
+            ", dataPadding='" + dataPadding + '\'' +
+            ", trailerType='" + trailerType + '\'' +
+            ", trailerPadding='" + trailerPadding + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final UnsupportedAnnotationModel validModel = (UnsupportedAnnotationModel) o;
+        return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
+            dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
+            trailerPadding, validModel.trailerPadding);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+    }
+
+    public static class UnsupportedAnnotationModelBuilder {
+
+        private String headerType;
+        private LocalDate createAt;
+        private String headerPadding;
+        private String dataType;
+        private String name;
+        private int age;
+        private String dataPadding;
+        private String trailerType;
+        private String trailerPadding;
+
+        public UnsupportedAnnotationModelBuilder headerType(final String headerType) {
+            this.headerType = headerType;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder createAt(final LocalDate createAt) {
+            this.createAt = createAt;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder headerPadding(final String headerPadding) {
+            this.headerPadding = headerPadding;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder dataType(final String dataType) {
+            this.dataType = dataType;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder name(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder age(final int age) {
+            this.age = age;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder dataPadding(final String dataPadding) {
+            this.dataPadding = dataPadding;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder trailerType(final String trailerType) {
+            this.trailerType = trailerType;
+            return this;
+        }
+
+        public UnsupportedAnnotationModelBuilder trailerPadding(final String trailerPadding) {
+            this.trailerPadding = trailerPadding;
+            return this;
+        }
+
+        public UnsupportedAnnotationModel build() {
+            return new UnsupportedAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        }
+
+    }
+
+}

--- a/src/test/java/fulltext/fixture/model/ValidModel.java
+++ b/src/test/java/fulltext/fixture/model/ValidModel.java
@@ -1,20 +1,18 @@
-package fulltext.model;
+package fulltext.fixture.model;
 
 import fulltext.annotation.Field;
-import fulltext.annotation.FullText;
 import fulltext.enums.Charset;
+import fulltext.annotation.FullText;
 import fulltext.enums.PadCharacter;
-import fulltext.enums.PadPosition;
 import java.time.LocalDate;
 import java.util.Objects;
 
 @FullText(
     length = 300,
     encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
-    padChar = PadCharacter.SPACE, // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
-    padPosition = PadPosition.LEFT_PAD // 명시하지 않을 경우 기본적으로 왼쪽에 패딩문자를 채워넣습니다.
+    padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
 )
-public class ValidOptionModel {
+public class ValidModel {
 
     @Field(length = 1)
     private String headerType;
@@ -28,10 +26,10 @@ public class ValidOptionModel {
     @Field(length = 1)
     private String dataType;
 
-    @Field(length = 10, padPosition = PadPosition.RIGHT_PAD) // @Field의 속성이 @FullText보다 우선됩니다.
+    @Field(length = 10)
     private String name;
 
-    @Field(length = 3, padChar = PadCharacter.ZERO) // @Field의 속성이 @FullText보다 우선됩니다.
+    @Field(length = 3)
     private int age;
 
     @Field(length = 86)
@@ -43,10 +41,10 @@ public class ValidOptionModel {
     @Field(length = 99)
     private String trailerPadding;
 
-    private ValidOptionModel() {
+    private ValidModel() {
     }
 
-    private ValidOptionModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+    private ValidModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
         final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
         this.headerType = headerType;
         this.createAt = createAt;
@@ -59,8 +57,8 @@ public class ValidOptionModel {
         this.trailerPadding = trailerPadding;
     }
 
-    public static ValidOptionModelBuilder builder() {
-        return new ValidOptionModelBuilder();
+    public static ValidModelBuilder builder() {
+        return new ValidModelBuilder();
     }
 
     @Override
@@ -86,7 +84,7 @@ public class ValidOptionModel {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final ValidOptionModel validModel = (ValidOptionModel) o;
+        final ValidModel validModel = (ValidModel) o;
         return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
             dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
             trailerPadding, validModel.trailerPadding);
@@ -97,7 +95,7 @@ public class ValidOptionModel {
         return Objects.hash(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
     }
 
-    public static class ValidOptionModelBuilder {
+    public static class ValidModelBuilder {
 
         private String headerType;
         private LocalDate createAt;
@@ -109,53 +107,53 @@ public class ValidOptionModel {
         private String trailerType;
         private String trailerPadding;
 
-        public ValidOptionModelBuilder headerType(final String headerType) {
+        public ValidModelBuilder headerType(final String headerType) {
             this.headerType = headerType;
             return this;
         }
 
-        public ValidOptionModelBuilder createAt(final LocalDate createAt) {
+        public ValidModelBuilder createAt(final LocalDate createAt) {
             this.createAt = createAt;
             return this;
         }
 
-        public ValidOptionModelBuilder headerPadding(final String headerPadding) {
+        public ValidModelBuilder headerPadding(final String headerPadding) {
             this.headerPadding = headerPadding;
             return this;
         }
 
-        public ValidOptionModelBuilder dataType(final String dataType) {
+        public ValidModelBuilder dataType(final String dataType) {
             this.dataType = dataType;
             return this;
         }
 
-        public ValidOptionModelBuilder name(final String name) {
+        public ValidModelBuilder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public ValidOptionModelBuilder age(final int age) {
+        public ValidModelBuilder age(final int age) {
             this.age = age;
             return this;
         }
 
-        public ValidOptionModelBuilder dataPadding(final String dataPadding) {
+        public ValidModelBuilder dataPadding(final String dataPadding) {
             this.dataPadding = dataPadding;
             return this;
         }
 
-        public ValidOptionModelBuilder trailerType(final String trailerType) {
+        public ValidModelBuilder trailerType(final String trailerType) {
             this.trailerType = trailerType;
             return this;
         }
 
-        public ValidOptionModelBuilder trailerPadding(final String trailerPadding) {
+        public ValidModelBuilder trailerPadding(final String trailerPadding) {
             this.trailerPadding = trailerPadding;
             return this;
         }
 
-        public ValidOptionModel build() {
-            return new ValidOptionModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        public ValidModel build() {
+            return new ValidModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
 
     }

--- a/src/test/java/fulltext/fixture/model/ValidOptionModel.java
+++ b/src/test/java/fulltext/fixture/model/ValidOptionModel.java
@@ -12,7 +12,7 @@ import java.util.Objects;
     length = 300,
     encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
     padChar = PadCharacter.SPACE, // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
-    padPosition = PadPosition.LEFT_PAD // 명시하지 않을 경우 기본적으로 왼쪽에 패딩문자를 채워넣습니다.
+    padPosition = PadPosition.LEFT // 명시하지 않을 경우 기본적으로 왼쪽에 패딩문자를 채워넣습니다.
 )
 public class ValidOptionModel {
 
@@ -28,7 +28,7 @@ public class ValidOptionModel {
     @Field(length = 1)
     private String dataType;
 
-    @Field(length = 10, padPosition = PadPosition.RIGHT_PAD) // @Field의 속성이 @FullText보다 우선됩니다.
+    @Field(length = 10, padPosition = PadPosition.RIGHT) // @Field의 속성이 @FullText보다 우선됩니다.
     private String name;
 
     @Field(length = 3, padChar = PadCharacter.ZERO) // @Field의 속성이 @FullText보다 우선됩니다.

--- a/src/test/java/fulltext/fixture/model/ValidOptionModel.java
+++ b/src/test/java/fulltext/fixture/model/ValidOptionModel.java
@@ -1,10 +1,20 @@
-package fulltext.model;
+package fulltext.fixture.model;
 
 import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import fulltext.enums.Charset;
+import fulltext.enums.PadCharacter;
+import fulltext.enums.PadPosition;
 import java.time.LocalDate;
 import java.util.Objects;
 
-public class NoClassAnnotationModel {
+@FullText(
+    length = 300,
+    encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
+    padChar = PadCharacter.SPACE, // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
+    padPosition = PadPosition.LEFT_PAD // 명시하지 않을 경우 기본적으로 왼쪽에 패딩문자를 채워넣습니다.
+)
+public class ValidOptionModel {
 
     @Field(length = 1)
     private String headerType;
@@ -18,10 +28,10 @@ public class NoClassAnnotationModel {
     @Field(length = 1)
     private String dataType;
 
-    @Field(length = 10)
+    @Field(length = 10, padPosition = PadPosition.RIGHT_PAD) // @Field의 속성이 @FullText보다 우선됩니다.
     private String name;
 
-    @Field(length = 3)
+    @Field(length = 3, padChar = PadCharacter.ZERO) // @Field의 속성이 @FullText보다 우선됩니다.
     private int age;
 
     @Field(length = 86)
@@ -33,10 +43,10 @@ public class NoClassAnnotationModel {
     @Field(length = 99)
     private String trailerPadding;
 
-    private NoClassAnnotationModel() {
+    private ValidOptionModel() {
     }
 
-    private NoClassAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+    private ValidOptionModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
         final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
         this.headerType = headerType;
         this.createAt = createAt;
@@ -49,8 +59,8 @@ public class NoClassAnnotationModel {
         this.trailerPadding = trailerPadding;
     }
 
-    public static NoClassAnnotationModelBuilder builder() {
-        return new NoClassAnnotationModelBuilder();
+    public static ValidOptionModelBuilder builder() {
+        return new ValidOptionModelBuilder();
     }
 
     @Override
@@ -76,7 +86,7 @@ public class NoClassAnnotationModel {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final NoClassAnnotationModel validModel = (NoClassAnnotationModel) o;
+        final ValidOptionModel validModel = (ValidOptionModel) o;
         return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
             dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
             trailerPadding, validModel.trailerPadding);
@@ -87,7 +97,7 @@ public class NoClassAnnotationModel {
         return Objects.hash(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
     }
 
-    public static class NoClassAnnotationModelBuilder {
+    public static class ValidOptionModelBuilder {
 
         private String headerType;
         private LocalDate createAt;
@@ -99,53 +109,53 @@ public class NoClassAnnotationModel {
         private String trailerType;
         private String trailerPadding;
 
-        public NoClassAnnotationModelBuilder headerType(final String headerType) {
+        public ValidOptionModelBuilder headerType(final String headerType) {
             this.headerType = headerType;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder createAt(final LocalDate createAt) {
+        public ValidOptionModelBuilder createAt(final LocalDate createAt) {
             this.createAt = createAt;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder headerPadding(final String headerPadding) {
+        public ValidOptionModelBuilder headerPadding(final String headerPadding) {
             this.headerPadding = headerPadding;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder dataType(final String dataType) {
+        public ValidOptionModelBuilder dataType(final String dataType) {
             this.dataType = dataType;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder name(final String name) {
+        public ValidOptionModelBuilder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder age(final int age) {
+        public ValidOptionModelBuilder age(final int age) {
             this.age = age;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder dataPadding(final String dataPadding) {
+        public ValidOptionModelBuilder dataPadding(final String dataPadding) {
             this.dataPadding = dataPadding;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder trailerType(final String trailerType) {
+        public ValidOptionModelBuilder trailerType(final String trailerType) {
             this.trailerType = trailerType;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder trailerPadding(final String trailerPadding) {
+        public ValidOptionModelBuilder trailerPadding(final String trailerPadding) {
             this.trailerPadding = trailerPadding;
             return this;
         }
 
-        public NoClassAnnotationModel build() {
-            return new NoClassAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        public ValidOptionModel build() {
+            return new ValidOptionModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
 
     }


### PR DESCRIPTION
`full-text-mapper-v1.2`까진 @fulltext와 @field에 default로 선언된 enum 속성이 동일하다.
이 때, @fulltext에 임의의 속성을 설정해 전역으로 사용하고자 해도 @field에 이미 기본값이 설정돼있어 적용되지 않는다.
따라서 @field는 기본적으로 아무런 속성을 사용하지 않는다는 의미의 `NONE`을 추가하고 이를 처리하는 코드가 필요하다.

따라서 리플렉터가 어노테이션에 정의된 `NONE`을 구분하도록 변경했다.

- @Field에 NONE이 선언돼있다면 @FullText의 속성을 반환한다
- @Field에 정의된 속성과 @FullText에 정의된 속성이 다르다면 @Field에 정의된 속성을 반환한다
- 모두 아닐 경우 @FullText의 속성을 반환한다