### PR TITLE
Release 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 <dependency>
   <groupId>io.github.shirohoo</groupId>
   <artifactId>full-text-mapper</artifactId>
-  <version>1.3</version>
+  <version>1.4</version>
 </dependency>
 ```
 
@@ -64,7 +64,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.github.shirohoo:full-text-mapper:1.3'
+    implementation 'io.github.shirohoo:full-text-mapper:1.4'
 }
 ```
 
@@ -72,7 +72,7 @@ dependencies {
 
 기본적으로 전문 한줄과 객체 한개가 일대일로 매핑됩니다.
 
-**이때 `기본생성자`가 반드시 필요하며, `접근제한자`는 `private`이여도 괜찮습니다.**
+**매핑을 하기 위해서는 `기본생성자`가 반드시 필요하며, `접근제한자`는 `private`이여도 괜찮습니다.**
 
 전문과 매핑될 클래스를 작성하고 `@FullText`를 클래스 레벨에, `@Field`를 필드 레벨에 정의합니다.
 
@@ -86,8 +86,8 @@ dependencies {
 - `int` or `Integer`
 - `long` or `Long`
 - `double` or `Double`
-- `LocalDate` - 현재 `yyyyMMdd`만 지원
-- `LocalDateTime` - 현재 `yyyyMMddHHmmss`만 지원
+- `LocalDate` - 기본 포맷 `yyyyMMdd` **(변경 가능)**
+- `LocalDateTime` - 기본 포맷 `yyyyMMddHHmmss` **(변경 가능)**
 - `BigDecimal`
 
 <br />
@@ -103,6 +103,8 @@ dependencies {
 - 클래스 레벨에 `@FullText`가 누락돼있다면 예외를 발생시킵니다.
 - 필드 레벨에 `@Field`가 누락돼있다면 예외를 발생시킵니다.
 - `@FullText`와 `@Field`의 속성들 (`PadPosition`, `PadCharacter`)이 모두 `NONE`이면 예외를 발생시킵니다.
+- `LocalDate`의 기본 포맷은 `yyyyMMdd` 이며, 이를 변경하기 위해서는 `@Field(localDateFormat = "{format}")`을 수정하십시오.
+- `LocalDateTime`의 기본 포맷은 `yyyyMMdd` 이며, 이를 변경하기 위해서는 `@Field(localDateTimeFormat = "{format}")`을 수정하십시오.
 
 <br />
 
@@ -118,12 +120,11 @@ dependencies {
     padPosition = PadPosition.LEFT_PAD // 명시하지 않을 경우 기본적으로 왼쪽에 패딩문자를 채워넣습니다.
 )
 public class ValidOptionModel {
-
     @Field(length = 1)
     private String headerType;
 
-    @Field(length = 8)
-    private LocalDate createAt; // yyyyMMdd
+    @Field(length = 10, localDateFormat = "yyyy-MM-dd") // 기본값은 yyyyMMdd 이며, 변경가능합니다.
+    private LocalDate createAt;
 
     @Field(length = 91)
     private String headerPadding;
@@ -137,7 +138,7 @@ public class ValidOptionModel {
     @Field(length = 3, padChar = PadCharacter.ZERO) // @Field의 속성이 @FullText보다 우선됩니다.
     private int age;
 
-    @Field(length = 86)
+    @Field(length = 84)
     private String dataPadding;
 
     @Field(length = 1)
@@ -145,7 +146,6 @@ public class ValidOptionModel {
 
     @Field(length = 99)
     private String trailerPadding;
-
 }
 ```
 
@@ -159,7 +159,7 @@ public class ValidOptionModel {
 
 ```java
 FullTextMapper mapper = FullTextMapperFactory.lineFullTextMapper();
-Optional<ValidModel> validModel = mapper.readValue(FullTextCreator.validData(), ValidModel.class);
+FullTextModel fullTextModel = mapper.readValue(getFullText(), FullTextModel.class);
 ```
 
 <br />
@@ -172,7 +172,13 @@ Optional<ValidModel> validModel = mapper.readValue(FullTextCreator.validData(), 
 
 ```java
 FullTextMapper mapper = FullTextMapperFactory.lineFullTextMapper();
-String fullText = mapper.write(ModelCreator.validModel());
+String fullText = mapper.write(getFullTextModel());
 ```
+
+<br />
+
+> 기본적으로 위 정보들만 숙지한다면 사용하는데 문제는 없을것입니다. 
+> 
+> 더욱 자세한 내용들이 궁금하다면 각 클래스에 정의된 javadoc을 참고하세요.
 
 <br />

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'io.github.shirohoo'
 archivesBaseName = 'full-text-mapper'
-version = '1.3'
+version = '1.4'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/src/main/java/fulltext/FullTextMapper.java
+++ b/src/main/java/fulltext/FullTextMapper.java
@@ -2,7 +2,6 @@ package fulltext;
 
 import fulltext.annotation.Field;
 import fulltext.annotation.FullText;
-import java.util.Optional;
 
 /**
  * <p>
@@ -13,26 +12,25 @@ import java.util.Optional;
  * In this case, Field property takes precedence over FullText.
  */
 public interface FullTextMapper {
-
     /**
      * After inputting the string data and class together, it maps the data to the instance of the input class and returns it.
      *
      * @param data  full text of string type
      * @param clazz map to full text
-     * @param <T> class in which {@link FullText} and {@link Field} are declared
-     * @return instance of Optional{@literal <}T{@literal >}
+     * @param <T>   class in which {@link FullText} and {@link Field} are declared
+     * @return instance of T
      */
-    <T> Optional<T> readValue(final String data, final Class<T> clazz);
+    <T> T readValue(final String data, final Class<T> clazz);
 
     /**
      * After inputting the byte array data and class together, it maps the data to the instance of the input class and returns it.
      *
+     * @param <T>   class in which {@link FullText} and {@link Field} are declared
      * @param data  full text of byte array type
      * @param clazz map to full text
-     * @param <T> class in which {@link FullText} and {@link Field} are declared
-     * @return instance of Optional{@literal <}T{@literal >}
+     * @return instance of T
      */
-    <T> Optional<T> readValue(final byte[] data, final Class<T> clazz);
+    <T> T readValue(final byte[] data, final Class<T> clazz);
 
     /**
      * It takes an object as input, refers to {@link FullText} and {@link Field} declared, and creates full text and returns it.
@@ -41,5 +39,4 @@ public interface FullTextMapper {
      * @return full text
      */
     String write(final Object object);
-
 }

--- a/src/main/java/fulltext/FullTextMapperFactory.java
+++ b/src/main/java/fulltext/FullTextMapperFactory.java
@@ -1,7 +1,6 @@
 package fulltext;
 
 public class FullTextMapperFactory {
-
     private FullTextMapperFactory() {
     }
 
@@ -15,9 +14,7 @@ public class FullTextMapperFactory {
     }
 
     private static class LineFullTextMapperHolder {
-
         private static final FullTextMapper instance = LineFullTextMapper.newInstance();
 
     }
-
 }

--- a/src/main/java/fulltext/annotation/Field.java
+++ b/src/main/java/fulltext/annotation/Field.java
@@ -8,6 +8,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.format.DateTimeFormatter;
 
 /**
  * {@link FullTextMapper} refers to this annotation to mapping the fields of the object to the full text.
@@ -18,7 +19,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Field {
-
     /**
      * length of this field
      *
@@ -42,4 +42,15 @@ public @interface Field {
      */
     PadPosition padPosition() default PadPosition.NONE;
 
+    /**
+     * This is the default format for LocalDate. Observe the format of DateTimeFormatter.
+     * @return LocalDate format
+     */
+    String localDateFormat() default "yyyyMMdd";
+
+    /**
+     * This is the default format for LocalDateTime. Observe the format of DateTimeFormatter.
+     * @return LocalDateTime format
+     */
+    String localDateTimeFormat() default "yyyyMMddHHmmss";
 }

--- a/src/main/java/fulltext/annotation/FullText.java
+++ b/src/main/java/fulltext/annotation/FullText.java
@@ -17,7 +17,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface FullText {
-
     /**
      * Means the total length of one line in full text.
      *
@@ -47,5 +46,4 @@ public @interface FullText {
      * @throws UnsupportedOperationException If @FullText.PadPosition and @Field.PadPosition are both PadPosition.NONE
      */
     PadPosition padPosition() default PadPosition.LEFT;
-
 }

--- a/src/main/java/fulltext/annotation/FullTextReflector.java
+++ b/src/main/java/fulltext/annotation/FullTextReflector.java
@@ -10,7 +10,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 public final class FullTextReflector {
-
     private FullTextReflector() {
     }
 
@@ -144,5 +143,4 @@ public final class FullTextReflector {
             .map(Field::length)
             .reduce(0, Integer::sum);
     }
-
 }

--- a/src/main/java/fulltext/enums/Charset.java
+++ b/src/main/java/fulltext/enums/Charset.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public enum Charset {
-
     UTF_8("UTF-8"),
     EUC_KR("EUC-KR"),
     ;
@@ -31,5 +30,4 @@ public enum Charset {
         }
         return MAP.get(charset);
     }
-
 }

--- a/src/main/java/fulltext/enums/ClassCaster.java
+++ b/src/main/java/fulltext/enums/ClassCaster.java
@@ -4,26 +4,25 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 public enum ClassCaster {
-
-    STRING(String.class, data -> data),
-    INT(int.class, Integer::valueOf),
-    INT_WRAPPER(Integer.class, Integer::valueOf),
-    LONG(long.class, Long::valueOf),
-    LONG_WRAPPER(Long.class, Long::valueOf),
-    DOUBLE(double.class, Double::valueOf),
-    DOUBLE_WRAPPER(Double.class, Double::valueOf),
-    LOCAL_DATE(LocalDate.class, data -> LocalDate.parse(data, DateTimeFormatter.BASIC_ISO_DATE)),
-    LOCAL_DATE_TIME(LocalDateTime.class, data -> LocalDateTime.parse(data, DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))),
-    BIG_DECIMAL(BigDecimal.class, BigDecimal::new),
+    STRING(String.class, (data, nonArgs) -> data),
+    INT(int.class, (data, nonArgs) -> Integer.valueOf(data)),
+    INT_WRAPPER(Integer.class, (data, nonArgs) -> Integer.valueOf(data)),
+    LONG(long.class, (data, nonArgs) -> Long.valueOf(data)),
+    LONG_WRAPPER(Long.class, (data, nonArgs) -> Long.valueOf(data)),
+    DOUBLE(double.class, (data, nonArgs) -> Double.valueOf(data)),
+    DOUBLE_WRAPPER(Double.class, (data, nonArgs) -> Double.valueOf(data)),
+    LOCAL_DATE(LocalDate.class, (data, format) -> LocalDate.parse(data, DateTimeFormatter.ofPattern(format))),
+    LOCAL_DATE_TIME(LocalDateTime.class, (data, format) -> LocalDateTime.parse(data, DateTimeFormatter.ofPattern(format))),
+    BIG_DECIMAL(BigDecimal.class, (data, nonArgs) -> new BigDecimal(data)),
     ;
 
     private final Class<?> clazz;
-    private final Function<String, ?> function;
+    private final BiFunction<String, String, ?> function;
 
-    ClassCaster(final Class<?> clazz, final Function<String, ?> function) {
+    ClassCaster(final Class<?> clazz, final BiFunction<String, String, ?> function) {
         this.clazz = clazz;
         this.function = function;
     }
@@ -32,8 +31,7 @@ public enum ClassCaster {
         return clazz;
     }
 
-    public Function<String, ?> getFunction() {
+    public BiFunction<String, String, ?> getFunction() {
         return function;
     }
-
 }

--- a/src/main/java/fulltext/enums/PadCharacter.java
+++ b/src/main/java/fulltext/enums/PadCharacter.java
@@ -1,7 +1,6 @@
 package fulltext.enums;
 
 public enum PadCharacter {
-
     NONE(""),
     SPACE(" "),
     ZERO("0"),
@@ -41,5 +40,4 @@ public enum PadCharacter {
         }
         return data;
     }
-
 }

--- a/src/main/java/fulltext/enums/PadPosition.java
+++ b/src/main/java/fulltext/enums/PadPosition.java
@@ -1,7 +1,6 @@
 package fulltext.enums;
 
 public enum PadPosition {
-
     NONE,
     LEFT,
     RIGHT,
@@ -14,5 +13,4 @@ public enum PadPosition {
     public boolean isLeft() {
         return this == LEFT;
     }
-
 }

--- a/src/main/java/fulltext/exception/RuleViolationException.java
+++ b/src/main/java/fulltext/exception/RuleViolationException.java
@@ -1,0 +1,13 @@
+package fulltext.exception;
+
+public class RuleViolationException extends RuntimeException {
+    public static final String defaultMessage = "You have violated the code convention rules of Full Text Mapper.";
+
+    public RuleViolationException() {
+        super(defaultMessage);
+    }
+
+    public RuleViolationException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/fulltext/ClassCasterTest.java
+++ b/src/test/java/fulltext/ClassCasterTest.java
@@ -15,33 +15,31 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class ClassCasterTest {
-
     @MethodSource
     @ParameterizedTest
-    void function(final String data, final Function<String, ?> function, final Object expected) throws Exception {
-        assertThat(function.apply(data)).isEqualTo(expected);
+    void function(final String data, final String format, final BiFunction<String, String, ?> function, final Object expected) throws Exception {
+        assertThat(function.apply(data, format)).isEqualTo(expected);
     }
 
     private static Stream<Arguments> function() {
         return Stream.of(
-            Arguments.of("1000", STRING.getFunction(), "1000"),
-            Arguments.of("1000", INT.getFunction(), 1000),
-            Arguments.of("1000", INT_WRAPPER.getFunction(), 1000),
-            Arguments.of("1000", LONG.getFunction(), 1000L),
-            Arguments.of("1000", LONG_WRAPPER.getFunction(), 1000L),
-            Arguments.of("1000.0", DOUBLE.getFunction(), 1000.0D),
-            Arguments.of("1000.0", DOUBLE_WRAPPER.getFunction(), 1000.0D),
-            Arguments.of("20201010", LOCAL_DATE.getFunction(), LocalDate.of(2020, 10, 10)),
-            Arguments.of("20201010000000", LOCAL_DATE_TIME.getFunction(), LocalDateTime.parse("20201010000000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))),
-            Arguments.of("1000", BIG_DECIMAL.getFunction(), new BigDecimal("1000"))
+            Arguments.of("1000", null, STRING.getFunction(), "1000"),
+            Arguments.of("1000", null, INT.getFunction(), 1000),
+            Arguments.of("1000", null, INT_WRAPPER.getFunction(), 1000),
+            Arguments.of("1000", null, LONG.getFunction(), 1000L),
+            Arguments.of("1000", null, LONG_WRAPPER.getFunction(), 1000L),
+            Arguments.of("1000.0", null, DOUBLE.getFunction(), 1000.0D),
+            Arguments.of("1000.0", null, DOUBLE_WRAPPER.getFunction(), 1000.0D),
+            Arguments.of("20201010", "yyyyMMdd", LOCAL_DATE.getFunction(), LocalDate.of(2020, 10, 10)),
+            Arguments.of("20201010000000", "yyyyMMddHHmmss", LOCAL_DATE_TIME.getFunction(), LocalDateTime.parse("20201010000000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))),
+            Arguments.of("1000", null, BIG_DECIMAL.getFunction(), new BigDecimal("1000"))
         );
     }
-
 }

--- a/src/test/java/fulltext/LineFullTextMapperTest.java
+++ b/src/test/java/fulltext/LineFullTextMapperTest.java
@@ -2,29 +2,69 @@ package fulltext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import fulltext.exception.RuleViolationException;
 import fulltext.fixture.FullTextCreator;
 import fulltext.fixture.ModelCreator;
 import fulltext.fixture.model.InvalidClassAnnotationModel;
+import fulltext.fixture.model.LocalDate1Model;
+import fulltext.fixture.model.LocalDate2Model;
+import fulltext.fixture.model.LocalDateTime1Model;
+import fulltext.fixture.model.LocalDateTime2Model;
+import fulltext.fixture.model.NoConstructorModel;
+import fulltext.fixture.model.NumbersBinding;
 import fulltext.fixture.model.UnsupportedAnnotationModel;
 import fulltext.fixture.model.ValidModel;
 import fulltext.fixture.model.ValidOptionModel;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class LineFullTextMapperTest {
-
-    private FullTextMapper mapper = FullTextMapperFactory.lineFullTextMapper();
+    FullTextMapper mapper = FullTextMapperFactory.lineFullTextMapper();
 
     @Test
     void readValue() throws Exception {
-        Optional<ValidModel> actual = mapper.readValue(FullTextCreator.VALID_DATA, ValidModel.class);
-        assertThat(actual.get()).isEqualTo(ModelCreator.VALID_MODEL);
+        ValidModel actual = mapper.readValue(FullTextCreator.VALID_DATA, ValidModel.class);
+        assertThat(actual).isEqualTo(ModelCreator.VALID_MODEL);
     }
 
     @Test
     void readValue_option() throws Exception {
-        Optional<ValidOptionModel> actual = mapper.readValue(FullTextCreator.VALID_OPTION_DATA, ValidOptionModel.class);
-        assertThat(actual.get()).isEqualTo(ModelCreator.VALID_OPTION_MODEL);
+        ValidOptionModel actual = mapper.readValue(FullTextCreator.VALID_OPTION_DATA, ValidOptionModel.class);
+        assertThat(actual).isEqualTo(ModelCreator.VALID_OPTION_MODEL);
+    }
+
+    @Test
+    void readValue_numbers() throws Exception {
+        NumbersBinding actual = mapper.readValue(FullTextCreator.NUMBERS_DATA, NumbersBinding.class);
+        assertAll(
+            () -> assertThat(actual.getIntValue()).isEqualTo(0),
+            () -> assertThat(actual.getLongValue()).isEqualTo(0),
+            () -> assertThat(actual.getDoubleValue()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    void readValue_localDate1() throws Exception {
+        LocalDate1Model actual = mapper.readValue(FullTextCreator.LOCAL_DATE1, LocalDate1Model.class);
+        assertThat(actual.getLocalDate()).isEqualTo("2020-12-31");
+    }
+
+    @Test
+    void readValue_localDate2() throws Exception {
+        LocalDate2Model actual = mapper.readValue(FullTextCreator.LOCAL_DATE2, LocalDate2Model.class);
+        assertThat(actual.getLocalDate()).isEqualTo("2020-12-31");
+    }
+
+    @Test
+    void readValue_localDateTime1() throws Exception {
+        LocalDateTime1Model actual = mapper.readValue(FullTextCreator.LOCAL_DATE_TIME1, LocalDateTime1Model.class);
+        assertThat(actual.getLocalDateTime()).isEqualTo("2020-12-31T12:00");
+    }
+
+    @Test
+    void readValue_localDateTime2() throws Exception {
+        LocalDateTime2Model actual = mapper.readValue(FullTextCreator.LOCAL_DATE_TIME2, LocalDateTime2Model.class);
+        assertThat(actual.getLocalDateTime()).isEqualTo("2020-12-31T12:00");
     }
 
     @Test
@@ -49,6 +89,13 @@ class LineFullTextMapperTest {
     }
 
     @Test
+    void readValue_exception_4() throws Exception {
+        assertThatThrownBy(() -> mapper.readValue(FullTextCreator.VALID_DATA, NoConstructorModel.class))
+            .isInstanceOf(RuleViolationException.class)
+            .hasMessage("No suitable constructor. Make sure fulltext.fixture.model.NoConstructorModel.<init>() has a default constructor");
+    }
+
+    @Test
     void write() throws Exception {
         String actual = mapper.write(ModelCreator.VALID_MODEL);
         assertThat(actual).isEqualTo(FullTextCreator.VALID_DATA);
@@ -59,5 +106,4 @@ class LineFullTextMapperTest {
         String actual = mapper.write(ModelCreator.VALID_OPTION_MODEL);
         assertThat(actual).isEqualTo(FullTextCreator.VALID_OPTION_DATA);
     }
-
 }

--- a/src/test/java/fulltext/PadCharacterTest.java
+++ b/src/test/java/fulltext/PadCharacterTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class PadCharacterTest {
-
     @MethodSource
     @ParameterizedTest
     void isNone(final PadCharacter padCharacter, final boolean expected) throws Exception {
@@ -100,5 +99,4 @@ class PadCharacterTest {
             Arguments.of(PadCharacter.ZERO, "", "")
         );
     }
-
 }

--- a/src/test/java/fulltext/annotation/FullTextReflectorTest.java
+++ b/src/test/java/fulltext/annotation/FullTextReflectorTest.java
@@ -13,7 +13,6 @@ import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
 class FullTextReflectorTest {
-
     @Test
     void findClassAnnotation() throws Exception {
         assertThat(FullTextReflector.findClassAnnotation(ValidModel.class)).isNotNull();
@@ -72,27 +71,27 @@ class FullTextReflectorTest {
 
     @Test
     void getPadCharacter() throws Exception {
-        // given
+        // ...given
         final FullText classAnnotation = FullTextReflector.findClassAnnotation(ValidOptionModel.class);
         final Field fieldAnnotation = FullTextReflector.findFieldAnnotation(validOptionAgeField());
 
-        // when
+        // ...when
         final PadCharacter padCharacter = FullTextReflector.getPadCharacter(classAnnotation, fieldAnnotation);
 
-        // then
+        // ...then
         assertThat(padCharacter).isEqualTo(PadCharacter.ZERO);
     }
 
     @Test
     void getPadPosition() throws Exception {
-        // given
+        // ...given
         final FullText classAnnotation = FullTextReflector.findClassAnnotation(ValidOptionModel.class);
         final Field fieldAnnotation = FullTextReflector.findFieldAnnotation(validOptionNameField());
 
-        // when
+        // ...when
         final PadPosition padPosition = FullTextReflector.getPadPosition(classAnnotation, fieldAnnotation);
 
-        // then
+        // ...then
         assertThat(padPosition).isEqualTo(PadPosition.RIGHT);
     }
 
@@ -129,5 +128,4 @@ class FullTextReflectorTest {
         final Class<?> clazz = Class.forName("fulltext.fixture.model.NoFieldAnnotationModel");
         return clazz.getDeclaredField("headerType");
     }
-
 }

--- a/src/test/java/fulltext/enums/PadPositionTest.java
+++ b/src/test/java/fulltext/enums/PadPositionTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class PadPositionTest {
-
     @MethodSource
     @ParameterizedTest
     void isNone(final PadPosition PadPosition, final boolean expected) throws Exception {
@@ -35,5 +34,4 @@ class PadPositionTest {
             Arguments.of(PadPosition.RIGHT, false)
         );
     }
-
 }

--- a/src/test/java/fulltext/fixture/FullTextCreator.java
+++ b/src/test/java/fulltext/fixture/FullTextCreator.java
@@ -1,13 +1,17 @@
 package fulltext.fixture;
 
 public final class FullTextCreator {
-
     public static final String VALID_DATA = "120211011                                                                                           " +
         "2      siro 28                                                                                      " +
         "3                                                                                                   ";
-    
+
     public static final String VALID_OPTION_DATA = "120211011                                                                                          " +
         " 2siro      028                                                                                     " +
         " 3                                                                                                   ";
 
+    public static final String NUMBERS_DATA = "000000000000000";
+    public static final String LOCAL_DATE1 = "20201231";
+    public static final String LOCAL_DATE2 = "2020-12-31";
+    public static final String LOCAL_DATE_TIME1 = "20201231120000";
+    public static final String LOCAL_DATE_TIME2 = "2020-12-31 12:00:00";
 }

--- a/src/test/java/fulltext/fixture/ModelCreator.java
+++ b/src/test/java/fulltext/fixture/ModelCreator.java
@@ -1,6 +1,10 @@
 package fulltext.fixture;
 
 import fulltext.fixture.model.InvalidClassAnnotationModel;
+import fulltext.fixture.model.LocalDate1Model;
+import fulltext.fixture.model.LocalDate2Model;
+import fulltext.fixture.model.LocalDateTime1Model;
+import fulltext.fixture.model.LocalDateTime2Model;
 import fulltext.fixture.model.NoClassAnnotationModel;
 import fulltext.fixture.model.ValidModel;
 import fulltext.fixture.model.ValidOptionModel;
@@ -8,7 +12,6 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 public final class ModelCreator {
-
     public static final ValidModel VALID_MODEL =
         ValidModel.builder()
             .headerType("1")
@@ -61,4 +64,8 @@ public final class ModelCreator {
             .trailerPadding("")
             .build();
 
+    public static final LocalDate1Model LOCAL_DATE1_MODEL = new LocalDate1Model(LocalDate.of(2000, 12, 31));
+    public static final LocalDate2Model LOCAL_DATE2_MODEL = new LocalDate2Model(LocalDate.of(2000, 12, 31));
+    public static final LocalDateTime1Model LOCAL_DATE_TIME1_MODEL = new LocalDateTime1Model(LocalDate.of(2000, 12, 31).atStartOfDay());
+    public static final LocalDateTime2Model LOCAL_DATE_TIME2_MODEL = new LocalDateTime2Model(LocalDate.of(2000, 12, 31).atStartOfDay());
 }

--- a/src/test/java/fulltext/fixture/model/InvalidClassAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/InvalidClassAnnotationModel.java
@@ -13,7 +13,6 @@ import java.util.Objects;
     padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
 )
 public class InvalidClassAnnotationModel {
-
     @Field(length = 1)
     private String headerType;
 
@@ -96,7 +95,6 @@ public class InvalidClassAnnotationModel {
     }
 
     public static class InvalidClassAnnotationModelBuilder {
-
         private String headerType;
         private LocalDate createAt;
         private String headerPadding;
@@ -155,7 +153,5 @@ public class InvalidClassAnnotationModel {
         public InvalidClassAnnotationModel build() {
             return new InvalidClassAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
-
     }
-
 }

--- a/src/test/java/fulltext/fixture/model/LocalDate1Model.java
+++ b/src/test/java/fulltext/fixture/model/LocalDate1Model.java
@@ -1,0 +1,22 @@
+package fulltext.fixture.model;
+
+import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import java.time.LocalDate;
+
+@FullText(length = 8)
+public class LocalDate1Model {
+    @Field(length = 8)
+    private LocalDate localDate;
+
+    public LocalDate1Model() {
+    }
+
+    public LocalDate1Model(LocalDate localDate) {
+        this.localDate = localDate;
+    }
+
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+}

--- a/src/test/java/fulltext/fixture/model/LocalDate2Model.java
+++ b/src/test/java/fulltext/fixture/model/LocalDate2Model.java
@@ -1,0 +1,22 @@
+package fulltext.fixture.model;
+
+import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import java.time.LocalDate;
+
+@FullText(length = 10)
+public class LocalDate2Model {
+    @Field(length = 10, localDateFormat = "yyyy-MM-dd")
+    private LocalDate localDate;
+
+    public LocalDate2Model() {
+    }
+
+    public LocalDate2Model(LocalDate localDate) {
+        this.localDate = localDate;
+    }
+
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+}

--- a/src/test/java/fulltext/fixture/model/LocalDateTime1Model.java
+++ b/src/test/java/fulltext/fixture/model/LocalDateTime1Model.java
@@ -1,0 +1,23 @@
+package fulltext.fixture.model;
+
+import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@FullText(length = 14)
+public class LocalDateTime1Model {
+    @Field(length = 14)
+    private LocalDateTime localDateTime;
+
+    public LocalDateTime1Model() {
+    }
+
+    public LocalDateTime1Model(LocalDateTime localDateTime) {
+        this.localDateTime = localDateTime;
+    }
+
+    public LocalDateTime getLocalDateTime() {
+        return localDateTime;
+    }
+}

--- a/src/test/java/fulltext/fixture/model/LocalDateTime2Model.java
+++ b/src/test/java/fulltext/fixture/model/LocalDateTime2Model.java
@@ -1,0 +1,22 @@
+package fulltext.fixture.model;
+
+import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import java.time.LocalDateTime;
+
+@FullText(length = 19)
+public class LocalDateTime2Model {
+    @Field(length = 19, localDateTimeFormat = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime localDateTime;
+
+    public LocalDateTime2Model() {
+    }
+
+    public LocalDateTime2Model(LocalDateTime localDateTime) {
+        this.localDateTime = localDateTime;
+    }
+
+    public LocalDateTime getLocalDateTime() {
+        return localDateTime;
+    }
+}

--- a/src/test/java/fulltext/fixture/model/NoConstructorModel.java
+++ b/src/test/java/fulltext/fixture/model/NoConstructorModel.java
@@ -1,10 +1,18 @@
 package fulltext.fixture.model;
 
 import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import fulltext.enums.Charset;
+import fulltext.enums.PadCharacter;
 import java.time.LocalDate;
 import java.util.Objects;
 
-public class NoClassAnnotationModel {
+@FullText(
+    length = 300,
+    encoding = Charset.UTF_8, // 명시하지 않을 경우 기본값은 UTF-8입니다.
+    padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
+)
+public class NoConstructorModel {
     @Field(length = 1)
     private String headerType;
 
@@ -32,10 +40,7 @@ public class NoClassAnnotationModel {
     @Field(length = 99)
     private String trailerPadding;
 
-    private NoClassAnnotationModel() {
-    }
-
-    private NoClassAnnotationModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
+    private NoConstructorModel(final String headerType, final LocalDate createAt, final String headerPadding, final String dataType,
         final String name, final int age, final String dataPadding, final String trailerType, final String trailerPadding) {
         this.headerType = headerType;
         this.createAt = createAt;
@@ -48,8 +53,8 @@ public class NoClassAnnotationModel {
         this.trailerPadding = trailerPadding;
     }
 
-    public static NoClassAnnotationModelBuilder builder() {
-        return new NoClassAnnotationModelBuilder();
+    public static NoConstructorModelBuilder builder() {
+        return new NoConstructorModelBuilder();
     }
 
     @Override
@@ -75,10 +80,10 @@ public class NoClassAnnotationModel {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final NoClassAnnotationModel validModel = (NoClassAnnotationModel) o;
-        return age == validModel.age && Objects.equals(headerType, validModel.headerType) && Objects.equals(createAt, validModel.createAt) && Objects.equals(headerPadding, validModel.headerPadding) && Objects.equals(
-            dataType, validModel.dataType) && Objects.equals(name, validModel.name) && Objects.equals(dataPadding, validModel.dataPadding) && Objects.equals(trailerType, validModel.trailerType) && Objects.equals(
-            trailerPadding, validModel.trailerPadding);
+        final NoConstructorModel model = (NoConstructorModel) o;
+        return age == model.age && Objects.equals(headerType, model.headerType) && Objects.equals(createAt, model.createAt) && Objects.equals(headerPadding, model.headerPadding) && Objects.equals(
+            dataType, model.dataType) && Objects.equals(name, model.name) && Objects.equals(dataPadding, model.dataPadding) && Objects.equals(trailerType, model.trailerType) && Objects.equals(
+            trailerPadding, model.trailerPadding);
     }
 
     @Override
@@ -86,7 +91,7 @@ public class NoClassAnnotationModel {
         return Objects.hash(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
     }
 
-    public static class NoClassAnnotationModelBuilder {
+    public static class NoConstructorModelBuilder {
         private String headerType;
         private LocalDate createAt;
         private String headerPadding;
@@ -97,53 +102,53 @@ public class NoClassAnnotationModel {
         private String trailerType;
         private String trailerPadding;
 
-        public NoClassAnnotationModelBuilder headerType(final String headerType) {
+        public NoConstructorModelBuilder headerType(final String headerType) {
             this.headerType = headerType;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder createAt(final LocalDate createAt) {
+        public NoConstructorModelBuilder createAt(final LocalDate createAt) {
             this.createAt = createAt;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder headerPadding(final String headerPadding) {
+        public NoConstructorModelBuilder headerPadding(final String headerPadding) {
             this.headerPadding = headerPadding;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder dataType(final String dataType) {
+        public NoConstructorModelBuilder dataType(final String dataType) {
             this.dataType = dataType;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder name(final String name) {
+        public NoConstructorModelBuilder name(final String name) {
             this.name = name;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder age(final int age) {
+        public NoConstructorModelBuilder age(final int age) {
             this.age = age;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder dataPadding(final String dataPadding) {
+        public NoConstructorModelBuilder dataPadding(final String dataPadding) {
             this.dataPadding = dataPadding;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder trailerType(final String trailerType) {
+        public NoConstructorModelBuilder trailerType(final String trailerType) {
             this.trailerType = trailerType;
             return this;
         }
 
-        public NoClassAnnotationModelBuilder trailerPadding(final String trailerPadding) {
+        public NoConstructorModelBuilder trailerPadding(final String trailerPadding) {
             this.trailerPadding = trailerPadding;
             return this;
         }
 
-        public NoClassAnnotationModel build() {
-            return new NoClassAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
+        public NoConstructorModel build() {
+            return new NoConstructorModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
     }
 }

--- a/src/test/java/fulltext/fixture/model/NoFieldAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/NoFieldAnnotationModel.java
@@ -12,23 +12,14 @@ import java.util.Objects;
     padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
 )
 public class NoFieldAnnotationModel {
-
     private String headerType;
-
-    private LocalDate createAt; // yyyyMMdd
-
+    private LocalDate createAt;
     private String headerPadding;
-
     private String dataType;
-
     private String name;
-
     private int age;
-
     private String dataPadding;
-
     private String trailerType;
-
     private String trailerPadding;
 
     private NoFieldAnnotationModel() {
@@ -86,7 +77,6 @@ public class NoFieldAnnotationModel {
     }
 
     public static class ValidModelBuilder {
-
         private String headerType;
         private LocalDate createAt;
         private String headerPadding;
@@ -145,7 +135,5 @@ public class NoFieldAnnotationModel {
         public NoFieldAnnotationModel build() {
             return new NoFieldAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
-
     }
-
 }

--- a/src/test/java/fulltext/fixture/model/NumbersBinding.java
+++ b/src/test/java/fulltext/fixture/model/NumbersBinding.java
@@ -1,0 +1,35 @@
+package fulltext.fixture.model;
+
+import fulltext.annotation.Field;
+import fulltext.annotation.FullText;
+import fulltext.enums.PadCharacter;
+
+@FullText(
+    length = 15,
+    padChar = PadCharacter.ZERO
+)
+public class NumbersBinding {
+    @Field(length = 5)
+    private Integer intValue;
+
+    @Field(length = 5)
+    private Long longValue;
+
+    @Field(length = 5)
+    private Double doubleValue;
+
+    public NumbersBinding() {
+    }
+
+    public Integer getIntValue() {
+        return intValue;
+    }
+
+    public Long getLongValue() {
+        return longValue;
+    }
+
+    public Double getDoubleValue() {
+        return doubleValue;
+    }
+}

--- a/src/test/java/fulltext/fixture/model/UnsupportedAnnotationModel.java
+++ b/src/test/java/fulltext/fixture/model/UnsupportedAnnotationModel.java
@@ -13,7 +13,6 @@ import java.util.Objects;
     padChar = PadCharacter.NONE // @Field도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
 )
 public class UnsupportedAnnotationModel {
-
     @Field(length = 1, padChar = PadCharacter.NONE) // @FullText도 PadCharacter.NONE 이므로 UnsupportedOperationException 예상
     private String headerType;
 
@@ -155,7 +154,5 @@ public class UnsupportedAnnotationModel {
         public UnsupportedAnnotationModel build() {
             return new UnsupportedAnnotationModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
-
     }
-
 }

--- a/src/test/java/fulltext/fixture/model/ValidModel.java
+++ b/src/test/java/fulltext/fixture/model/ValidModel.java
@@ -13,7 +13,6 @@ import java.util.Objects;
     padChar = PadCharacter.SPACE // 명시하지 않을 경우 기본값은 공백문자(" ")입니다.
 )
 public class ValidModel {
-
     @Field(length = 1)
     private String headerType;
 
@@ -155,7 +154,5 @@ public class ValidModel {
         public ValidModel build() {
             return new ValidModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
-
     }
-
 }

--- a/src/test/java/fulltext/fixture/model/ValidOptionModel.java
+++ b/src/test/java/fulltext/fixture/model/ValidOptionModel.java
@@ -15,7 +15,6 @@ import java.util.Objects;
     padPosition = PadPosition.LEFT // 명시하지 않을 경우 기본적으로 왼쪽에 패딩문자를 채워넣습니다.
 )
 public class ValidOptionModel {
-
     @Field(length = 1)
     private String headerType;
 
@@ -98,7 +97,6 @@ public class ValidOptionModel {
     }
 
     public static class ValidOptionModelBuilder {
-
         private String headerType;
         private LocalDate createAt;
         private String headerPadding;
@@ -157,7 +155,5 @@ public class ValidOptionModel {
         public ValidOptionModel build() {
             return new ValidOptionModel(headerType, createAt, headerPadding, dataType, name, age, dataPadding, trailerType, trailerPadding);
         }
-
     }
-
 }


### PR DESCRIPTION
- [x] `Number Type`에 패딩문자 ZERO 설정 후 "00000" 와 같은 입력이 들어오면 ""가 입력되는 버그를 수정했다
- [x] 기본생성자가 없을 경우 더 친절한 예외 메시지가 출력되록 수정했다
- [x] 날짜타입 포매팅을 커스터마이징 할 수 있게 수정했다
- [x] 사용자 편의성을 위해 `FullTextMapper`의 `readValue`가 반환하는 값이 `Optional`이 아니게 변경했다.